### PR TITLE
Add directory creation rsource for conf-available

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@pingworks.de'
 license          'Apache License, Version 2.0'
 description      'Installs/Configures chef-dash'
 long_description 'Installs/Configures chef-dash'
-version '0.3.10'
+version '0.3.11'
 
 supports 'debian'
 

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -19,6 +19,14 @@
 
 apt_package 'apache2'
 
+directory '/etc/apache2/conf-available' do
+  owner 'root'
+  group 'root'
+  mode 00755
+  recursive true
+  action :create
+end
+
 directory '/etc/apache2/conf.d' do
   owner 'root'
   group 'root'

--- a/test/integration/default/serverspec/localhost/dash-prod_spec.rb
+++ b/test/integration/default/serverspec/localhost/dash-prod_spec.rb
@@ -16,6 +16,10 @@ describe package('libapache2-mod-php5') do
   it { should be_installed }
 end
 
+describe file '/etc/apache2/conf-available' do
+  it { should exist }
+end
+
 describe file '/etc/apache2/sites-available/dash-prod' do
   its (:content) { should match /DocumentRoot \/opt\/dash\/public/ }
   its (:content) { should match /SetEnv APPLICATION_ENV "production"/ }


### PR DESCRIPTION
Hi Alex and Christoph,

It looks like most of the environment cookbooks in vagrant-ci fail with below error after we upgraded to a latest version of chef-dash.  I think this might be due to non-existing /etc/apache2/conf-available directory.  Therefore I made this change and added a corresponding test. If OK could you please merge it in?

**Error Stacktrace:**

 Recipe: chef-dash::repo
         \* apt_package[apache2] action install
           - install version 2.2.22-13+deb7u6 of package apache2
        (up to date)
         \* template[/etc/apache2/conf-available/repo.conf] action create
           \* Parent directory /etc/apache2/conf-available does not exist.
           ================================================================================
           Error executing action `create` on resource 'template[/etc/apache2/conf-available/repo.conf]'
           ================================================================================

```
       Chef::Exceptions::EnclosingDirectoryDoesNotExist
       ------------------------------------------------
       Parent directory /etc/apache2/conf-available does not exist.

       Resource Declaration:
       ---------------------
       # In /tmp/kitchen/cache/cookbooks/chef-dash/recipes/repo.rb

        34: template tplfile do
        35:   source 'confd_repo_alias.erb'
        36:   owner "root"
        37:   group "root"
        38:   mode '644'
        39: end
        40: 

   Compiled Resource:
       ------------------
   # Declared in /tmp/kitchen/cache/cookbooks/chef-dash/recipes/repo.rb:34:in `from_file'

       template("/etc/apache2/conf-available/repo.conf") do
         provider Chef::Provider::Template
         action "create"
         retries 0
         retry_delay 2
         guard_interpreter :default

         backup 5
         atomic_update true
         source "confd_repo_alias.erb"
         cookbook_name "chef-dash"
         recipe_name "repo"
         owner "root"
         group "root"
         mode "644"
       end
```
