### PR TITLE
#5 box-url in kitchen.yml returns 404

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,8 +9,8 @@ provisioner:
 platforms:
   - name: debian-7.7
     driver:
-        box: opscode_debian-7.7_chef-11.16.4-1
-        box_url: http://vagrant.pingworks.net/opscode_debian-7.7_chef-11.16.4-1.box
+        box: debianstandard_20150428_1258
+        box_url: http://vagrantimages.yrdci.fra.hybris.com/debianstandard_20150428_1258.box
   - name: debian-8
     driver:
         box: debian/jessie64

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Supported Platforms
 
 Debian 7.x (wheezy)
+Debian 8 (jessie)
 
 ## Attributes
 
@@ -54,4 +55,3 @@ Apache v2.0 License
 
 Author:: Christoph Lukas (<lukas@pingworks.de>)
 Author:: Alexander Birk (<birk@pingworks.de>)
-


### PR DESCRIPTION
kitchen-tests are green for both debian-versions afterwards :-)
